### PR TITLE
fix(web): sharpen Liquid Glass sidebar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,32 +161,154 @@
 
 /* No position rule here: users of this class position themselves with
    Tailwind (fixed drawer / relative rail), and a plain class rule would
-   override those same-specificity utilities. ::after's inset-0 relies on
-   the element being positioned by its own classes. */
+   override those same-specificity utilities. The pseudo-elements' inset-0
+   relies on the element being positioned by its own classes. */
 .liquid-glass-panel {
-	background: linear-gradient(180deg, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0.62) 100%);
-	backdrop-filter: blur(24px) saturate(170%) brightness(104%);
-	-webkit-backdrop-filter: blur(24px) saturate(170%) brightness(104%);
+	isolation: isolate;
+	overflow: hidden;
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.68) 0%, rgba(250, 247, 240, 0.48) 100%);
+	backdrop-filter: blur(14px) saturate(145%) brightness(104%) contrast(102%);
+	-webkit-backdrop-filter: blur(14px) saturate(145%) brightness(104%) contrast(102%);
+	box-shadow:
+		18px 0 48px rgba(35, 28, 18, 0.08),
+		inset -1px 0 0 rgba(255, 255, 255, 0.52),
+		inset 1px 0 0 rgba(255, 255, 255, 0.22);
 }
 
 .dark .liquid-glass-panel {
-	background: linear-gradient(180deg, rgba(26, 26, 31, 0.6) 0%, rgba(11, 11, 14, 0.78) 100%);
+	background: linear-gradient(180deg, rgba(24, 24, 27, 0.46) 0%, rgba(8, 8, 10, 0.66) 100%);
+	box-shadow:
+		18px 0 52px rgba(0, 0, 0, 0.34),
+		inset -1px 0 0 rgba(255, 255, 255, 0.10),
+		inset 1px 0 0 rgba(255, 255, 255, 0.045);
 }
 
+.liquid-glass-panel::before,
 .liquid-glass-panel::after {
 	content: "";
 	position: absolute;
 	inset: 0;
+	z-index: 0;
 	pointer-events: none;
+}
+
+.liquid-glass-panel::before {
 	background:
-		radial-gradient(130% 32% at 30% 0%, rgba(255, 255, 255, 0.16) 0%, transparent 65%),
-		linear-gradient(90deg, transparent 94%, rgba(255, 255, 255, 0.06) 100%);
+		radial-gradient(92% 36% at 12% -2%, rgba(255, 202, 87, 0.14) 0%, transparent 68%),
+		radial-gradient(68% 48% at 108% 38%, rgba(165, 182, 219, 0.11) 0%, transparent 70%);
+}
+
+.liquid-glass-panel::after {
+	background:
+		linear-gradient(90deg, rgba(255, 255, 255, 0.15) 0, transparent 8%, transparent 88%, rgba(255, 255, 255, 0.20) 100%),
+		linear-gradient(180deg, rgba(255, 255, 255, 0.24) 0, transparent 18%, transparent 82%, rgba(255, 255, 255, 0.06) 100%);
+}
+
+.dark .liquid-glass-panel::before {
+	background:
+		radial-gradient(92% 36% at 12% -2%, rgba(251, 191, 36, 0.075) 0%, transparent 68%),
+		radial-gradient(68% 48% at 108% 38%, rgba(138, 154, 193, 0.055) 0%, transparent 70%);
 }
 
 .dark .liquid-glass-panel::after {
 	background:
-		radial-gradient(130% 32% at 30% 0%, rgba(255, 255, 255, 0.07) 0%, transparent 65%),
-		linear-gradient(90deg, transparent 94%, rgba(255, 255, 255, 0.04) 100%);
+		linear-gradient(90deg, rgba(255, 255, 255, 0.035) 0, transparent 8%, transparent 88%, rgba(255, 255, 255, 0.085) 100%),
+		linear-gradient(180deg, rgba(255, 255, 255, 0.075) 0, transparent 18%, transparent 82%, rgba(255, 255, 255, 0.018) 100%);
+}
+
+.liquid-glass-panel > * {
+	position: relative;
+	z-index: 1;
+}
+
+.sidebar-brand-icon {
+	filter: none;
+	image-rendering: auto;
+	transform: translateZ(0);
+}
+
+.sidebar-brand-wordmark {
+	font-synthesis: none;
+	text-rendering: geometricPrecision;
+}
+
+.sidebar-glass-control,
+.sidebar-glass-button {
+	border: 1px solid rgba(105, 78, 24, 0.16);
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.14)),
+		rgba(217, 119, 6, 0.06);
+	backdrop-filter: blur(10px) saturate(135%);
+	-webkit-backdrop-filter: blur(10px) saturate(135%);
+	box-shadow:
+		0 8px 24px rgba(101, 72, 20, 0.08),
+		inset 0 1px 0 rgba(255, 255, 255, 0.72),
+		inset 0 -1px 0 rgba(112, 78, 17, 0.06);
+}
+
+.sidebar-glass-button {
+	border-color: rgba(30, 24, 16, 0.10);
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.12));
+	box-shadow:
+		0 6px 20px rgba(35, 28, 18, 0.055),
+		inset 0 1px 0 rgba(255, 255, 255, 0.66),
+		inset 0 -1px 0 rgba(30, 24, 16, 0.045);
+}
+
+.sidebar-glass-control:hover,
+.sidebar-glass-button:hover {
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(255, 255, 255, 0.19)),
+		rgba(217, 119, 6, 0.075);
+	box-shadow:
+		0 10px 28px rgba(101, 72, 20, 0.105),
+		inset 0 1px 0 rgba(255, 255, 255, 0.82),
+		inset 0 -1px 0 rgba(112, 78, 17, 0.075);
+}
+
+.dark .sidebar-glass-control,
+.dark .sidebar-glass-button {
+	border-color: rgba(251, 191, 36, 0.18);
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.095), rgba(255, 255, 255, 0.025)),
+		rgba(251, 191, 36, 0.065);
+	box-shadow:
+		0 9px 26px rgba(0, 0, 0, 0.24),
+		inset 0 1px 0 rgba(255, 255, 255, 0.15),
+		inset 0 -1px 0 rgba(255, 255, 255, 0.025);
+}
+
+.dark .sidebar-glass-button {
+	border-color: rgba(255, 255, 255, 0.09);
+	background: linear-gradient(180deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.018));
+}
+
+.dark .sidebar-glass-control:hover,
+.dark .sidebar-glass-button:hover {
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.035)),
+		rgba(251, 191, 36, 0.08);
+	box-shadow:
+		0 11px 30px rgba(0, 0, 0, 0.30),
+		inset 0 1px 0 rgba(255, 255, 255, 0.19),
+		inset 0 -1px 0 rgba(255, 255, 255, 0.035);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+	.liquid-glass-panel,
+	.sidebar-glass-control,
+	.sidebar-glass-button {
+		backdrop-filter: none;
+		-webkit-backdrop-filter: none;
+	}
+
+	.liquid-glass-panel {
+		background: #f4f1eb;
+	}
+
+	.dark .liquid-glass-panel {
+		background: #111113;
+	}
 }
 
 /* ═══════════════════════════════════════

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -78,20 +78,22 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
 			)}
 
 			<aside
-				className={`${positioning} z-50 w-[85vw] max-w-72 lg:w-[268px] flex-col liquid-glass-panel border-r border-black/[0.08] dark:border-white/[0.06]`}
+				className={`${positioning} z-50 w-[85vw] max-w-72 lg:w-[268px] flex-col liquid-glass-panel`}
 			>
 				{/* Brand */}
-				<div className="flex items-center gap-2.5 px-4 pt-4 pb-3">
+				<div className="flex items-center gap-2.5 px-4 pt-4 pb-3.5">
 					<Image
-						src="/web-app-manifest-512x512.png"
+						src="/favicon-96x96.png"
 						alt=""
-						width={30}
-						height={30}
-						className="rounded-lg"
+						width={34}
+						height={34}
+						priority
+						unoptimized
+						className="sidebar-brand-icon shrink-0"
 					/>
 					<Link
 						href="/"
-						className="text-amber-600 dark:text-amber-400 font-bold text-xl font-[family-name:var(--font-pirata)] drop-shadow-[0_0_8px_rgba(200,160,40,0.3)]"
+						className="sidebar-brand-wordmark text-[23px] leading-none font-normal text-amber-600 dark:text-amber-300 font-[family-name:var(--font-pirata)]"
 					>
 						SureWord
 					</Link>
@@ -115,9 +117,9 @@ const AppSidebar: React.FC<AppSidebarProps> = ({
 								key={id}
 								href={href}
 								aria-current={isActive ? "page" : undefined}
-								className={`flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-sm font-medium border transition-all duration-150 ${
+								className={`flex items-center gap-2.5 px-3 py-2.5 rounded-[14px] text-sm font-medium border transition-[color,background-color,border-color,box-shadow,transform] duration-200 active:scale-[0.985] ${
 									isActive
-										? "bg-amber-500/10 dark:bg-amber-400/10 text-amber-600 dark:text-amber-400 border-amber-500/25 dark:border-amber-400/20 glow-amber-sm"
+										? "sidebar-glass-control text-amber-700 dark:text-amber-300"
 										: "text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-black/[0.04] dark:hover:bg-white/[0.04] border-transparent"
 								}`}
 							>

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -36,7 +36,7 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
 					onNewChat();
 					onNavigate?.();
 				}}
-				className="w-full flex items-center gap-2 px-3 py-2.5 rounded-xl gradient-border bg-black/[0.03] dark:bg-white/[0.03] text-neutral-600 dark:text-neutral-400 hover:bg-black/[0.06] dark:hover:bg-white/[0.06] hover:text-neutral-900 dark:hover:text-neutral-200 transition-colors text-sm"
+				className="sidebar-glass-button w-full flex items-center gap-2 px-3 py-2.5 rounded-[14px] text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-white transition-[color,background-color,border-color,box-shadow,transform] duration-200 active:scale-[0.985] text-sm"
 			>
 				<Plus className="w-4 h-4 text-amber-600 dark:text-amber-400" />
 				New Chat


### PR DESCRIPTION
## Summary
- Make the SureWord sidebar read as layered, reflective glass instead of a blurred gray sheet.
- Keep the brand mark and wordmark crisp while preserving the existing navigation structure and behavior.

## Changes
- src/app/globals.css: reduce panel blur, layer reflections behind content, add specular control treatments, and add a reduced-transparency fallback.
- src/components/AppSidebar.tsx: use the compact 96px brand asset at 34px and remove synthetic bold and glyph glow.
- src/components/ChatSidebar.tsx: apply the same interactive glass depth to New Chat.
- No environment variables were added or renamed.
- Commit: https://github.com/spragginsdesigns/bible-ai-explorer/commit/2774868b9e8c541f6af521221e7baebcf6081556

## Verification
- pnpm lint passes with no warnings or errors.
- pnpm exec tsc --noEmit passes.
- pnpm build compiles successfully and generates all 31 static pages.
- Vercel preview deployment dpl_8EKQs7g78HRJNwqqBt4yPFZ87k6Z is READY for commit 2774868.
- Signed-in Chrome at localhost:3000 rendered the updated sidebar with the real account, dark theme, the 96px source icon at 34px, Pirata One at 23px/400, no brand filter or text shadow, no Next error overlay, and zero console errors after a clean dev-server restart.
- Break attempt: switched the signed-in product path to light mode and confirmed the warm translucent panel, amber-600 wordmark, and 10% control edge remained legible, then restored dark mode.

## Test plan
- [ ] Open the signed-in Chat page in dark mode at desktop width.
- [ ] Confirm the SureWord icon and wordmark are crisp at 100% browser zoom.
- [ ] Hover and press Chat and New Chat, then confirm the glass response does not blur their text or icons.
- [ ] Switch to light mode and confirm the panel remains legible.
- [ ] Enable reduced transparency where supported and confirm the solid fallback remains legible.

## Out of scope / Follow-ups
- The native macOS and mobile clients are unchanged.
- The existing test:logic model-selection assertion is stale and unrelated to this visual change; it expects a literal GPT-5.6 Terra call while the route now resolves the configured model dynamically.
- Vercel warns that the project must move from Node 20 to Node 24 before October 1, 2026.